### PR TITLE
Remove extraneous image tab on subtitle page

### DIFF
--- a/subtitle_window.py
+++ b/subtitle_window.py
@@ -373,12 +373,6 @@ class SubtitleWindow(QDialog):
         label_sub = QLabel("Subtitles")
         layout.addWidget(label_sub)
 
-
-        # Tab widget to show generated images
-        self.image_tab_widget = QTabWidget()
-        layout.addWidget(self.image_tab_widget)
-
-
         self.list_widget = QListWidget()
         self.list_widget.itemDoubleClicked.connect(self.on_item_double_clicked)
         layout.addWidget(self.list_widget)


### PR DESCRIPTION
## Summary
- clean up UI so the subtitle page does not include an unused image frame

## Testing
- `python -m py_compile subtitle_window.py`
- `python -m py_compile *.py`
