### PR TITLE
Add DALL‑E 3 for word image generation

### DIFF
--- a/image_generation_thread.py
+++ b/image_generation_thread.py
@@ -27,7 +27,12 @@ class ImageGenerationThread(QThread):
         openai.api_key = self.api_key
         prompt = generate_prompt_for_word(self.word)
         try:
-            response = openai.Image.create(prompt=prompt, n=1, size="512x512")
+            response = openai.Image.create(
+                prompt=prompt,
+                n=1,
+                size="512x512",
+                model="dall-e-3",
+            )
             image_url = response["data"][0]["url"]
             image_data = requests.get(image_url).content
         except Exception as e:

--- a/subtitle_window.py
+++ b/subtitle_window.py
@@ -59,7 +59,12 @@ class WordImageWorker(QThread):
 
         try:
             openai.api_key = self.api_key
-            response = openai.Image.create(prompt=self.prompt, n=1, size="512x512")
+            response = openai.Image.create(
+                prompt=self.prompt,
+                n=1,
+                size="512x512",
+                model="dall-e-3",
+            )
             image_url = response["data"][0]["url"]
             image_data = requests.get(image_url).content
             self.finished.emit(image_data)


### PR DESCRIPTION
## Summary
- use `model="dall-e-3"` for background image generation thread
- use DALL‑E 3 when generating images for words in the word viewer

## Testing
- `python -m py_compile *.py`