### PR TITLE
Fix word image generation errors

### DIFF
--- a/image_generation_thread.py
+++ b/image_generation_thread.py
@@ -28,6 +28,9 @@ class ImageGenerationThread(QThread):
         prompt = generate_prompt_for_word(self.word)
         try:
             response = openai.Image.create(prompt=prompt, n=1, size="512x512")
+            # The API should return a dict containing data -> [{"url": ...}].
+            if not response.get("data") or "url" not in response["data"][0]:
+                raise ValueError(f"Unexpected response format: {response}")
             image_url = response["data"][0]["url"]
             image_data = requests.get(image_url).content
         except Exception as e:

--- a/subtitle_window.py
+++ b/subtitle_window.py
@@ -3228,6 +3228,20 @@ class SubtitleWindow(QDialog):
         import uuid
         from PyQt5.QtWidgets import QMessageBox
 
+        image_filename = f"word_image_{uuid.uuid4().hex}.png"
+        b64_data = base64.b64encode(image_data).decode("utf-8")
+        res = self.anki.invoke("storeMediaFile", filename=image_filename, data=b64_data)
+        if res is None:
+            QMessageBox.warning(self, "Anki Error", "Could not store the image in Anki’s media collection.")
+        else:
+            new_tag = f'<img src="{image_filename}">' 
+            existing = self.field_image.text().strip()
+            updated = (existing + " " + new_tag).strip()
+            self.field_image.setText(updated)
+            QMessageBox.information(self, "Word Image Generated", f"Generated image for '{self._pending_word_image_word}'.")
+
+        self.word_image_worker = None
+
 
     # ------------------------------------------------------------------
     # Word Viewer helpers


### PR DESCRIPTION
## Summary
- improve error handling in `ImageGenerationThread` when image URL is missing
- implement `on_word_image_generated` to save and display generated images

## Testing
- `python -m py_compile image_generation_thread.py subtitle_window.py`

------
https://chatgpt.com/codex/tasks/task_e_683a236c3204832fb81e3d5be96e16cb