### PR TITLE
Add Kanji parsing controls on Study page

### DIFF
--- a/database_manager.py
+++ b/database_manager.py
@@ -2084,6 +2084,15 @@ class DatabaseManager:
             )
         self._conn.commit()
 
+    def count_deferred_kanji(self) -> int:
+        """Return the number of surface forms waiting for kanji parsing."""
+        cur = self._conn.cursor()
+        cur.execute(
+            "SELECT COUNT(*) FROM surface_forms WHERE kanji_parsed = 0"
+        )
+        row = cur.fetchone()
+        return row[0] if row else 0
+
     def increment_surface_form_frequency(self, surface_form_id: int):
         cur = self._conn.cursor()
         cur.execute("UPDATE surface_forms SET frequency = frequency + 1 WHERE surface_form_id = ?", (surface_form_id,))

--- a/main.py
+++ b/main.py
@@ -694,6 +694,8 @@ class CentralHub(QMainWindow):
         if new_widget == self.page_study_explore:
             # Now load the random sentence only when user lands on Explore
             self.load_random_sentence_explore()
+        elif new_widget == self.page_study_kanji:
+            self.refresh_deferred_kanji_count()
 
     def jump_to_time(self, start_time: float):
         """
@@ -2714,6 +2716,17 @@ class CentralHub(QMainWindow):
         self.db.parse_pending_kanji()
         self.statusBar().showMessage("Kanji parsing complete.")
 
+    def on_parse_deferred_kanji_clicked(self):
+        """Slot for the button on the Kanji study tab."""
+        self.parse_pending_kanji()
+        self.refresh_deferred_kanji_count()
+
+    def refresh_deferred_kanji_count(self):
+        """Update the label showing how many entries still need parsing."""
+        count = self.db.count_deferred_kanji()
+        if hasattr(self, "label_deferred_kanji"):
+            self.label_deferred_kanji.setText(f"Deferred Kanji: {count}")
+
     ##########################################################################
     # Study Page
     ##########################################################################
@@ -3036,8 +3049,16 @@ class CentralHub(QMainWindow):
     def create_study_kanji_page(self) -> QWidget:
         page = QWidget()
         layout = QVBoxLayout(page)
-        layout.addWidget(QLabel("Kanji Tab Placeholder - Coming Soon!"))
+
+        self.label_deferred_kanji = QLabel("Deferred Kanji: 0")
+        layout.addWidget(self.label_deferred_kanji)
+
+        btn_parse = QPushButton("Parse Deferred Kanji")
+        btn_parse.clicked.connect(self.on_parse_deferred_kanji_clicked)
+        layout.addWidget(btn_parse)
+
         layout.addStretch()
+        self.refresh_deferred_kanji_count()
         return page
 
     def create_study_explore_page(self) -> QWidget:


### PR DESCRIPTION
## Summary
- add a label and button to the Kanji tab
- allow parsing of deferred Kanji from the Study tab
- show how many surface forms still need kanji parsing
- expose DB helper for counting deferred kanji

## Testing
- `python -m py_compile database_manager.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_683b1947bdb0832faaf954fb281c524e