### PR TITLE
Add TMDb API key configuration

### DIFF
--- a/deck_editor.py
+++ b/deck_editor.py
@@ -41,6 +41,7 @@ class DeckEditorWindow(QWidget):
         self.anki_media_path = self.config.get("PATHS", "anki_media_path", fallback="")
         self.google_credentials = self.config['PATHS'].get('google_credentials_json', '')
         self.openai_api_key = self.config['DEFAULT'].get('OpenAI_API_Key', '')
+        self.tmdb_api_key = self.config['DEFAULT'].get('TMDB_API_Key', '')
 
         # QMediaPlayer for audio playback
         self.audio_player = QMediaPlayer()

--- a/explore_words_window.py
+++ b/explore_words_window.py
@@ -23,6 +23,7 @@ class ExploreWordsWindow(QMainWindow):
         self.config = configparser.ConfigParser()
         self.config.read(config_path)
         self.anki_media_path = self.config.get("PATHS", "anki_media_path", fallback="")
+        self.tmdb_api_key = self.config['DEFAULT'].get('TMDB_API_Key', '')
 
         # Audio player
         self.player = QMediaPlayer()

--- a/main.py
+++ b/main.py
@@ -134,6 +134,13 @@ def ensure_config():
     if not os.path.exists(CONFIG_PATH):
         print(f"No config.ini found. Creating a minimal one at {CONFIG_PATH}")
         with open(CONFIG_PATH, 'w', encoding='utf-8') as f:
+            # Provide a DEFAULT section with placeholder API keys so users
+            # know what can be configured.
+            f.write("[DEFAULT]\n")
+            f.write("OpenAI_API_Key =\n")
+            f.write("TMDB_API_Key =\n\n")
+
+            # Section used by the deck field mapping dialog
             f.write("[FIELD_MAPPINGS]\n")
     # Otherwise, it already exists
 
@@ -459,6 +466,7 @@ class CentralHub(QMainWindow):
         self.anki_media_path = self.config.get("PATHS", "anki_media_path", fallback="")
         self.google_credentials = self.config.get("PATHS", "google_credentials_json", fallback="")
         self.openai_api_key = self.config.get("DEFAULT", "OpenAI_API_Key", fallback="")
+        self.tmdb_api_key = self.config.get("DEFAULT", "TMDB_API_Key", fallback="")
 
         # Create a QMediaPlayer for playing audio in the Deck Editor
         self.audio_player = QMediaPlayer()
@@ -1355,6 +1363,7 @@ class CentralHub(QMainWindow):
                 anki_media_path=self.anki_media_path,
                 audio_player=self.audio_player,
                 openai_api_key=self.openai_api_key,  # pass the key along
+                tmdb_api_key=self.tmdb_api_key,
             )
             # Connect the signal here
             self.subtitle_window.subtitleDoubleClicked.connect(self.jump_to_time)

--- a/subtitle_window.py
+++ b/subtitle_window.py
@@ -257,7 +257,8 @@ class SubtitleWindow(QDialog):
     pausePlayRequested = pyqtSignal()
     editorBackToSubtitles = pyqtSignal()
     def __init__(self, subtitle_lines=None, parent=None, db_manager=None, anki_connector=None,
-                 google_credentials=None, anki_media_path="", audio_player=None, openai_api_key=""):
+                 google_credentials=None, anki_media_path="", audio_player=None,
+                 openai_api_key="", tmdb_api_key=""):
         super().__init__(parent)
         self.db_manager = db_manager
         self.anki = anki_connector
@@ -265,6 +266,7 @@ class SubtitleWindow(QDialog):
         self.anki_media_path = anki_media_path
         self.audio_player = audio_player
         self.openai_api_key = openai_api_key
+        self.tmdb_api_key = tmdb_api_key
         self.parser = ContentParser()
         self._subtitle_lines = []
 


### PR DESCRIPTION
## Summary
- extend `ensure_config()` to populate `config.ini` with placeholders for OpenAI and TMDb API keys
- read TMDb API key from config in CentralHub and pass it to `SubtitleWindow`
- expose the TMDb API key in `SubtitleWindow`, `DeckEditorWindow`, and `ExploreWordsWindow`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683b1cc81750832f8d0247177150d1d5