### PR TITLE
Implement filename parsing helper

### DIFF
--- a/file_utils.py
+++ b/file_utils.py
@@ -1,0 +1,42 @@
+import re
+
+
+def normalize_filename(stem: str) -> str:
+    """Normalize a filename by removing bracketed tags, replacing separators and
+    collapsing whitespace."""
+    temp = re.sub(r"\[.*?\]", "", stem)
+    temp = temp.replace('-', ' ')
+    temp = temp.replace('_', ' ')
+    temp = re.sub(r"\s+", " ", temp)
+    return temp.strip().lower()
+
+
+def parse_filename_for_show_episode(stem: str):
+    """Return (title, season, episode) parsed from filename stem.
+
+    Season and episode are integers or ``None`` when not found.
+    """
+    name = normalize_filename(stem)
+
+    # remove year like (2022) or resolution info like (1080p) etc
+    # strip parenthesized groups commonly containing year or resolution
+    name = re.sub(r"\([^)]*(?:\d{3,4}p|(?:19|20)\d{2}|x\d{3})[^)]*\)", "", name, flags=re.I)
+    name = re.sub(r"\([^)]*blu[- ]?ray[^)]*\)", "", name, flags=re.I)
+    name = name.strip()
+
+    patterns = [
+        re.compile(r"^(?P<title>.+?)\bs(?P<season>\d{1,2})e(?P<episode>\d{1,3})\b", re.I),
+        re.compile(r"^(?P<title>.+?)\b(?P<season>\d{1,2})x(?P<episode>\d{1,3})\b", re.I),
+        re.compile(r"^(?P<title>.+?)\b(?:episode|ep)\s*(?P<episode>\d{1,3})\b", re.I),
+        re.compile(r"^(?P<title>.+?)\b(?P<episode>\d{1,3})$", re.I),
+    ]
+
+    for pat in patterns:
+        m = pat.search(name)
+        if m:
+            title = m.group('title').strip()
+            season = int(m.group('season')) if 'season' in m.groupdict() and m.group('season') else None
+            episode = int(m.group('episode')) if 'episode' in m.groupdict() and m.group('episode') else None
+            return title, season, episode
+
+    return name, None, None

--- a/main.py
+++ b/main.py
@@ -11,6 +11,7 @@ from typing import Optional
 import openai
 import requests
 import re
+from file_utils import normalize_filename, parse_filename_for_show_episode
 
 
 # -------------------------------------------------------------------
@@ -838,14 +839,8 @@ class CentralHub(QMainWindow):
         self.db._conn.commit()
 
     def normalize_filename(self, stem: str) -> str:
-        """
-        Remove bracketed tags like [MTBB], [4D8BA5C7],
-        convert multiple spaces/dashes, etc.
-        """
-        temp = re.sub(r'\[.*?\]', '', stem)  # remove [stuff]
-        temp = temp.replace('-', ' ')
-        temp = re.sub(r'\s+', ' ', temp)
-        return temp.strip().lower()  # optional .lower()
+        """Wrapper around :func:`file_utils.normalize_filename`."""
+        return normalize_filename(stem)
 
     def walk_and_index(self, folder_path: str):
         logger.info(f"Starting walk_and_index for folder: {folder_path}")
@@ -881,8 +876,11 @@ class CentralHub(QMainWindow):
                 media_id = self.db.add_media(str(vid_path), media_type="video")
                 exact_stem = vid_path.stem
                 norm_stem = self.normalize_filename(exact_stem)
+                show, season, episode = parse_filename_for_show_episode(exact_stem)
                 logger.info(
                     f"Video path='{vid_path}', exact_stem='{exact_stem}', norm_stem='{norm_stem}' => media_id={media_id}")
+                logger.debug(
+                    f"Parsed title='{show}', season={season}, episode={episode}")
 
                 video_map_exact[exact_stem] = (media_id, vid_path)
                 video_map_normalized[norm_stem] = (media_id, vid_path)

--- a/tests/test_filename_parsing.py
+++ b/tests/test_filename_parsing.py
@@ -1,0 +1,24 @@
+import unittest
+from file_utils import parse_filename_for_show_episode
+
+class TestFilenameParsing(unittest.TestCase):
+    def test_subsplease(self):
+        title, season, episode = parse_filename_for_show_episode("[SubsPlease] Kaijuu 8-gou - 01 (480p) [E7479F2F]")
+        self.assertEqual(title, "kaijuu 8 gou")
+        self.assertIsNone(season)
+        self.assertEqual(episode, 1)
+
+    def test_judas(self):
+        title, season, episode = parse_filename_for_show_episode("[Judas] Digimon Adventure - S01E01")
+        self.assertEqual(title, "digimon adventure")
+        self.assertEqual(season, 1)
+        self.assertEqual(episode, 1)
+
+    def test_coalgirls(self):
+        title, season, episode = parse_filename_for_show_episode("[Coalgirls]_My_Neighbor_Totoro_(1280x692_Blu-ray_FLAC)_[949BDC65]")
+        self.assertEqual(title, "my neighbor totoro")
+        self.assertIsNone(season)
+        self.assertIsNone(episode)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `file_utils` module with `normalize_filename` and `parse_filename_for_show_episode`
- use helper functions in `main.walk_and_index`
- add unit tests covering filename parsing

## Testing
- `python -m unittest tests/test_filename_parsing.py`
- `python -m unittest`


------
https://chatgpt.com/codex/tasks/task_e_683b1e02691c832f866981906529f996