### PR TITLE
Add manual episode metadata dialog

### DIFF
--- a/metadata_edit_dialog.py
+++ b/metadata_edit_dialog.py
@@ -1,0 +1,47 @@
+from PyQt5.QtWidgets import (
+    QDialog, QVBoxLayout, QFormLayout, QLineEdit,
+    QDialogButtonBox
+)
+
+
+class MetadataEditDialog(QDialog):
+    """Simple dialog to enter or correct episode metadata."""
+
+    def __init__(self, show: str = "", season: int = None, episode: int = None, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Edit Metadata")
+
+        layout = QVBoxLayout(self)
+        form = QFormLayout()
+
+        self.title_edit = QLineEdit(show)
+        self.season_edit = QLineEdit(str(season) if season is not None else "")
+        self.episode_edit = QLineEdit(str(episode) if episode is not None else "")
+
+        form.addRow("Show Title:", self.title_edit)
+        form.addRow("Season:", self.season_edit)
+        form.addRow("Episode:", self.episode_edit)
+
+        layout.addLayout(form)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+    def get_values(self):
+        show = self.title_edit.text().strip()
+        season_text = self.season_edit.text().strip()
+        episode_text = self.episode_edit.text().strip()
+
+        try:
+            season = int(season_text) if season_text else None
+        except ValueError:
+            season = None
+
+        try:
+            episode = int(episode_text) if episode_text else None
+        except ValueError:
+            episode = None
+
+        return show, season, episode


### PR DESCRIPTION
## Summary
- let users fix metadata
- allow editing of show title, season and episode from the media browser

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683b2232f7b0832faf178a4d42f9ff31