### PR TITLE
Update Anki editor tabs

### DIFF
--- a/file_utils.py
+++ b/file_utils.py
@@ -111,9 +111,7 @@ def parse_filename_for_show_episode(stem: str):
             if "episode" in m.groupdict() and m.group("episode"):
                 episode = int(m.group("episode"))
 
-            # If no explicit season was found but an episode is present, default season to 1
-            if season is None and episode is not None:
-                season = 1
+
 
             return title, season, episode
 

--- a/subtitle_window.py
+++ b/subtitle_window.py
@@ -1794,9 +1794,10 @@ class SubtitleWindow(QDialog):
         outer_layout.addSpacerItem(QSpacerItem(10, 10))
         editor_page.setLayout(outer_layout)
 
-        tab_widget.addTab(editor_page, "Card Editor")
+        tab_widget.addTab(editor_page, "Card Contents")
+        tab_widget.addTab(QWidget(), "Images")
+        tab_widget.addTab(QWidget(), "Audio")
         tab_widget.addTab(QWidget(), "Dictionary")
-        tab_widget.addTab(QWidget(), "Word Viewer")
 
         parent_widget.setLayout(main_vbox)
 


### PR DESCRIPTION
## Summary
- rename Anki editor tabs and add placeholders for Images and Audio
- fix filename parsing not to default season to 1 when absent

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b4d11c618832fae76bbebb8116fac